### PR TITLE
Update jade template to include trailing dot on script tag

### DIFF
--- a/lib/templates/jade/layout.js
+++ b/lib/templates/jade/layout.js
@@ -18,7 +18,7 @@ html
                 li
                     a(href='' ) Other
         block content
-        script
+        script.
             YUI().use('node-base', 'event-base', function (Y) {
                 
             });


### PR DESCRIPTION
Without the trailing dot, the console gives us:

`Implicit textOnly for`script`and`style`is deprecated.  Use`script.`or`style.`instead.`
